### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "ruby main.rb"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Console.new.start
 Main file: [main.rb](/main.rb)
 
 Aviable locales: ru, en
+
+[![Run on Repl.it](https://repl.it/badge/github/andrewpetrenko1/codebreaker_ap-console)](https://repl.it/github/andrewpetrenko1/codebreaker_ap-console)
+


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment.